### PR TITLE
Fix single line of Arabic text distortion 

### DIFF
--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":[],"times":{"Omaralalwi\\Gpdf\\Tests\\GpdfTest::testConfigFileExists":0.001,"Omaralalwi\\Gpdf\\Tests\\GpdfTest::testConfigFileKeys":0,"Omaralalwi\\Gpdf\\Tests\\GpdfTest::testCreatePdf":0.059,"Omaralalwi\\Gpdf\\Tests\\GpdfTest::testArabicContent":0.028,"Omaralalwi\\Gpdf\\Tests\\GpdfTest::testUtf8GlyphsCalledWithSpecificParams":0.004}}

--- a/config/gpdf.php
+++ b/config/gpdf.php
@@ -1,7 +1,11 @@
 <?php
 
-use Omaralalwi\Gpdf\Enums\{GpdfDefaultSettings as GpdfDefault, GpdfSettingKeys as GpdfSet,
-    GpdfStorageDrivers, GpdfDefaultSupportedFonts};
+use Omaralalwi\Gpdf\Enums\{
+    GpdfDefaultSettings as GpdfDefault,
+    GpdfSettingKeys as GpdfSet,
+    GpdfStorageDrivers,
+    GpdfDefaultSupportedFonts
+};
 
 /**
  * Configuration file for the Gpdf package.
@@ -23,13 +27,13 @@ return [
      * Directory for storing font files.
      * @var string
      */
-    GpdfSet::FONT_DIR => realpath(__DIR__.GpdfDefault::FONT_DIR),
+    GpdfSet::FONT_DIR => realpath(__DIR__ . GpdfDefault::FONT_DIR),
 
     /**
      * Directory for storing font cache files.
      * @var string
      */
-    GpdfSet::FONT_CACHE =>  realpath(__DIR__.GpdfDefault::FONT_DIR), // same to font dir to avoid cache problems
+    GpdfSet::FONT_CACHE =>  realpath(__DIR__ . GpdfDefault::FONT_DIR), // same to font dir to avoid cache problems
 
     /**
      * Default font for generating PDFs.
@@ -45,6 +49,14 @@ return [
      * @var bool
      */
     GpdfSet::SHOW_NUMBERS_AS_HINDI => false,
+
+    /**
+     *
+     * Set Max number of chars you can fit in one line, default is 50
+     *
+     * @var integer
+     */
+    GpdfSet::MAX_CHARS_PER_LINE => 50,
 
     /**
      * Font height ratio setting.

--- a/src/Builders/PdfBuilder.php
+++ b/src/Builders/PdfBuilder.php
@@ -157,7 +157,7 @@ class PdfBuilder
 
         for ($i = count($p) - 1; $i >= 0; $i -= 2) {
             $utf8ar = $Arabic->utf8Glyphs(substr($htmlContent, $p[$i - 1], $p[$i] - $p[$i - 1]), $max_chars);
-            $utf8ar = nl2br($utf8ar);
+            //$utf8ar = nl2br($utf8ar);
 
             $htmlContent   = substr_replace($htmlContent, $utf8ar, $p[$i - 1], $p[$i] - $p[$i - 1]);
         }

--- a/src/Builders/PdfBuilder.php
+++ b/src/Builders/PdfBuilder.php
@@ -157,7 +157,7 @@ class PdfBuilder
 
         for ($i = count($p) - 1; $i >= 0; $i -= 2) {
             $utf8ar = $Arabic->utf8Glyphs(substr($htmlContent, $p[$i - 1], $p[$i] - $p[$i - 1]), $max_chars);
-            //$utf8ar = nl2br($utf8ar);
+            $utf8ar = nl2br($utf8ar);
 
             $htmlContent   = substr_replace($htmlContent, $utf8ar, $p[$i - 1], $p[$i] - $p[$i - 1]);
         }

--- a/src/Builders/PdfBuilder.php
+++ b/src/Builders/PdfBuilder.php
@@ -157,6 +157,8 @@ class PdfBuilder
 
         for ($i = count($p) - 1; $i >= 0; $i -= 2) {
             $utf8ar = $Arabic->utf8Glyphs(substr($htmlContent, $p[$i - 1], $p[$i] - $p[$i - 1]), $max_chars);
+            $utf8ar = nl2br($utf8ar);
+
             $htmlContent   = substr_replace($htmlContent, $utf8ar, $p[$i - 1], $p[$i] - $p[$i - 1]);
         }
 

--- a/src/Enums/GpdfSettingKeys.php
+++ b/src/Enums/GpdfSettingKeys.php
@@ -8,6 +8,7 @@ class GpdfSettingKeys
     const FONT_DIR = 'fontDir';
     const FONT_CACHE = 'fontCache';
     const SHOW_NUMBERS_AS_HINDI = 'showNumbersAsHindi';
+    const MAX_CHARS_PER_LINE = 'maxCharsPerLine';
     const CHROOT = 'chroot';
     const STORAGE_PATH = 'storage_path';
     const AWS_BUCKET = 'aws_storage_bucket';
@@ -71,5 +72,4 @@ class GpdfSettingKeys
         }
         return $keysObject;
     }
-
 }


### PR DESCRIPTION
This is proposal for fixing a single Arabic line rendering issue, please check the following image
![Screenshot from 2024-09-04 22-31-17](https://github.com/user-attachments/assets/6677219c-0b37-44b3-bf2e-7ae74f97b82c)


The original text is 

![Screenshot from 2024-09-04 22-05-47](https://github.com/user-attachments/assets/b43bf788-8ea4-4e54-abfa-13cdc9193b39)


![Screenshot from 2024-09-04 22-58-19](https://github.com/user-attachments/assets/625a42b2-1ee3-4c21-b932-fe20651897a9)

After a refactoring of the code is made the text was rendered correctly but did not take the full available space

![Screenshot from 2024-09-04 22-56-06](https://github.com/user-attachments/assets/8f8f5d18-7cd7-45f0-9ef0-637f194bf47e)

But by allow the user to change the `max_chars` in `gpdf.conf` from default `50` to for example in my case `110`, the issue was fixed

![Screenshot from 2024-09-04 22-56-47](https://github.com/user-attachments/assets/f0f37b87-3895-437c-a048-ee1a33e463cf)


![Screenshot from 2024-09-04 22-57-14](https://github.com/user-attachments/assets/7e331716-6ca3-4358-b5ad-ea7abeb69a9a)


This [solution](https://github.com/khaled-alshamaa/ar-php/issues/15#issuecomment-874103250) allowed me to figure out to fix the issue, as it has been proposed by the author of the package `khaled-alshamaa/ar-php`
